### PR TITLE
Free up tensorboard and tf estimator versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 /__pycache__
+
+*.avi
+*.wav

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,9 +161,9 @@ six==1.12.0
 sklearn==0.0
 SoundFile==0.10.2
 statsmodels==0.10.0
-tensorboard==1.15.0
+tensorboard
 tensorflow==1.15.2
-tensorflow-estimator==1.15.0
+tensorflow-estimator
 termcolor==1.1.0
 Twisted==19.7.0
 txaio==18.8.1


### PR DESCRIPTION
A minor change to free up the version of tensorboard and tensorflow-estimator because tensorflow 1.15.2 wasn't matching with 1.15.0 for tensorboard and tensorflow-estimator.